### PR TITLE
Create PUBLIC_HEALTH_CHECK.yml

### DIFF
--- a/.github/workflows/PUBLIC_HEALTH_CHECK.yml
+++ b/.github/workflows/PUBLIC_HEALTH_CHECK.yml
@@ -1,0 +1,42 @@
+name: Public Health Pledge Badging Check
+on:
+  schedule:
+    - cron: 0 5 1 6,12 *
+
+jobs:
+  create_issue:
+    name: Check Public Health Pledge 
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue
+        run: |
+          if [[ $CLOSE_PREVIOUS == true ]]; then
+            previous_issue_number=$(gh issue list \
+              --label "$LABELS" \
+              --json number \
+              --jq '.[0].number')
+            if [[ -n $previous_issue_number ]]; then
+              gh issue close "$previous_issue_number"
+              gh issue unpin "$previous_issue_number"
+            fi
+          fi
+          new_issue_url=$(gh issue create \
+            --title "$TITLE" \
+            --assignee "$ASSIGNEES" \
+            --label "$LABELS" \
+            --body "$BODY")
+          if [[ $PINNED == true ]]; then
+            gh issue pin "$new_issue_url"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TITLE: Check Public Health Pledge Badging
+          ASSIGNEES: elizabethn
+          LABELS: check
+          BODY: |
+            Check the [Public Health Pledge Badge](https://publichealthpledge.com/badging) for updates, as this is tied to our DEI Event Badging Application.
+          PINNED: false
+          CLOSE_PREVIOUS: false


### PR DESCRIPTION
**Summary:**

During the DEI meeting this week, we discussed implementing a check of the status of the [Public Health Pledge Badging program](https://publichealthpledge.com/badging). Because our DEI Event Badging Application refers to this other program, we should keep up to date with any changes they make.

**Changes**
This action *should* open an issue automatically on the 1st of June and December as a reminder for us to do a check.

**Testing:**

I haven't tested this because honestly, I'm not sure how to test it without running it here.

**Additional Notes:**

@adeyinkaoresanya or @kaxada it would be great if you can verify that I've written this correctly. (Or should I say, that I copied it from GitHub Docs and revised it correctly 😆) Thank you!
