### PR TITLE
Refine PHPledge questions based on DEI Working Group feedback from September 4, 2024

### DIFF
--- a/.github/checklist.md
+++ b/.github/checklist.md
@@ -51,6 +51,6 @@
 - [ ] **Findability** - Any cause for concern is communicated to attendees and is easy to find on the website.
 
 ### Public Health and Safety
-- [ ] **Public Health Pledge Badge** - The Event organizers have participated in the [Public Health Badging Program](https://publichealthpledge.com).
+- [ ] **Public Health Pledge Badge** - The Event organizers are aware of the [Public Health Badging Program](https://publichealthpledge.com).
 - [ ] **Findability** - Information about public health and safety procedures and provisions is publicly available on the event website.
 


### PR DESCRIPTION
**Summary:**

This PR refines the PHPledge questions based on feedback received from the DEI Working Group meeting on September 4, 2024.

**Changes:**

-  .github/checklist.md:  The change rephrases the description of the "Public Health Pledge Badge" checklist item to clarify that event organizers are aware of the program rather than having participated in it.

**Testing:**

- Manually reviewed the questionnaire rendering on the staging environment.
