### PR TITLE
feat: add 'Last Assigned Date' to Reviewer Spotlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,71 +40,71 @@ Four statuses exist for the Diversity and Inclusion Event Badging:
 ## ✨Reviewer Spotlight  
 
 ### Active Reviewers (last 6 months)  
-| Reviewer | Reviews (last 6 months) | Total Reviews | Last Review Date | Badge Level | Events Reviewed |
-|----------|----------------------|---------------|------------------|-------------------|--------|
-| [Anita-ihuman](https://github.com/Anita-ihuman) | 3 | 40 | 2026-01-27 | 🥇 Gold | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Anita-ihuman+is:closed) |
-| [tetris4](https://github.com/tetris4) | 3 | 30 | 2026-02-10 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:tetris4+is:closed) |
-| [KafayahL](https://github.com/KafayahL) | 2 | 27 | 2026-02-02 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:KafayahL+is:closed) |
-| [djmitche](https://github.com/djmitche) | 2 | 27 | 2025-09-23 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:djmitche+is:closed) |
-| [peculiaruc](https://github.com/peculiaruc) | 5 | 24 | 2026-01-29 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:peculiaruc+is:closed) |
-| [Maryblessing](https://github.com/Maryblessing) | 3 | 24 | 2026-01-27 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Maryblessing+is:closed) |
-| [adeyinkaoresanya](https://github.com/adeyinkaoresanya) | 2 | 23 | 2025-09-17 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:adeyinkaoresanya+is:closed) |
-| [oma131](https://github.com/oma131) | 2 | 20 | 2026-02-02 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:oma131+is:closed) |
-| [Young-W1](https://github.com/Young-W1) | 5 | 19 | 2026-02-16 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Young-W1+is:closed) |
-| [Busayo-ojo](https://github.com/Busayo-ojo) | 2 | 19 | 2025-10-20 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Busayo-ojo+is:closed) |
-| [harmonyelendu](https://github.com/harmonyelendu) | 7 | 18 | 2026-02-02 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:harmonyelendu+is:closed) |
-| [daluclemas](https://github.com/daluclemas) | 2 | 14 | 2026-01-22 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:daluclemas+is:closed) |
-| [divya-mohan0209](https://github.com/divya-mohan0209) | 4 | 13 | 2026-01-16 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:divya-mohan0209+is:closed) |
-| [Ijeoma-Onwuka](https://github.com/Ijeoma-Onwuka) | 4 | 12 | 2026-02-10 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Ijeoma-Onwuka+is:closed) |
-| [Amalearner](https://github.com/Amalearner) | 3 | 11 | 2026-02-02 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Amalearner+is:closed) |
-| [ijayhub](https://github.com/ijayhub) | 3 | 10 | 2026-02-02 | 🥉 Bronze | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:ijayhub+is:closed) |
-| [JacobIsah](https://github.com/JacobIsah) | 3 | 9 | 2026-02-10 | 🥉 Bronze | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:JacobIsah+is:closed) |
-| [winnerbright](https://github.com/winnerbright) | 3 | 9 | 2026-02-16 | 🥉 Bronze | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:winnerbright+is:closed) |
-| [Arya-AD](https://github.com/Arya-AD) | 3 | 8 | 2026-02-02 | 🥉 Bronze | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Arya-AD+is:closed) |
-| [Mo-wo](https://github.com/Mo-wo) | 1 | 7 | 2026-02-10 | 🥉 Bronze | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Mo-wo+is:closed) |
+| Reviewer | Reviews (last 6 months) | Total Reviews | Last Review Date | Last Assigned Date | Badge Level | Events Reviewed |
+|----------|-------------------------|---------------|------------------|--------------------|-------------|---------------- |
+| [Anita-ihuman](https://github.com/Anita-ihuman) | 3 | 40 | 2026-01-27 | 2026-01-19 | 🥇 Gold | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Anita-ihuman+is:closed)
+| [tetris4](https://github.com/tetris4) | 3 | 30 | 2026-02-10 | 2026-02-02 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:tetris4+is:closed)
+| [KafayahL](https://github.com/KafayahL) | 2 | 27 | 2026-02-02 | 2026-01-27 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:KafayahL+is:closed)
+| [djmitche](https://github.com/djmitche) | 2 | 27 | 2025-09-23 | 2025-09-17 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:djmitche+is:closed)
+| [peculiaruc](https://github.com/peculiaruc) | 5 | 24 | 2026-01-29 | 2026-01-27 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:peculiaruc+is:closed)
+| [Maryblessing](https://github.com/Maryblessing) | 3 | 24 | 2026-01-27 | 2026-01-19 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Maryblessing+is:closed)
+| [adeyinkaoresanya](https://github.com/adeyinkaoresanya) | 2 | 23 | 2025-09-17 | 2025-09-17 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:adeyinkaoresanya+is:closed)
+| [oma131](https://github.com/oma131) | 2 | 20 | 2026-02-02 | 2026-01-27 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:oma131+is:closed)
+| [Young-W1](https://github.com/Young-W1) | 5 | 19 | 2026-02-16 | 2026-02-02 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Young-W1+is:closed)
+| [Busayo-ojo](https://github.com/Busayo-ojo) | 2 | 19 | 2025-10-20 | 2025-10-06 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Busayo-ojo+is:closed)
+| [harmonyelendu](https://github.com/harmonyelendu) | 7 | 18 | 2026-02-02 | 2026-01-27 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:harmonyelendu+is:closed)
+| [daluclemas](https://github.com/daluclemas) | 2 | 14 | 2026-01-22 | 2026-01-14 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:daluclemas+is:closed)
+| [divya-mohan0209](https://github.com/divya-mohan0209) | 4 | 13 | 2026-01-16 | 2026-01-14 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:divya-mohan0209+is:closed)
+| [Ijeoma-Onwuka](https://github.com/Ijeoma-Onwuka) | 4 | 12 | 2026-02-10 | 2026-02-02 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Ijeoma-Onwuka+is:closed)
+| [Amalearner](https://github.com/Amalearner) | 3 | 11 | 2026-02-02 | 2026-01-27 | 🥈 Silver | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Amalearner+is:closed)
+| [ijayhub](https://github.com/ijayhub) | 3 | 10 | 2026-02-02 | 2026-01-27 | 🥉 Bronze | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:ijayhub+is:closed)
+| [JacobIsah](https://github.com/JacobIsah) | 3 | 9 | 2026-02-10 | 2026-02-10 | 🥉 Bronze | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:JacobIsah+is:closed)
+| [winnerbright](https://github.com/winnerbright) | 3 | 9 | 2026-02-16 | 2026-02-02 | 🥉 Bronze | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:winnerbright+is:closed)
+| [Arya-AD](https://github.com/Arya-AD) | 3 | 8 | 2026-02-02 | 2026-01-27 | 🥉 Bronze | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Arya-AD+is:closed)
+| [Mo-wo](https://github.com/Mo-wo) | 1 | 7 | 2026-02-10 | 2026-02-10 | 🥉 Bronze | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Mo-wo+is:closed)
 
 ---
 
 ### Past Reviewers  
-| Reviewer | Total Reviews | Last Active | Badge Level | Events Reviewed |
-|----------|---------------|-------------|-------------------|--------|
-| [Ruth-ikegah](https://github.com/Ruth-ikegah) | 30 | 2023-08-17 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Ruth-ikegah+is:closed) |
-| [ElizabethN](https://github.com/ElizabethN) | 26 | 2025-06-26 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:ElizabethN+is:closed) |
-| [germonprez](https://github.com/germonprez) | 25 | 2024-03-18 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:germonprez+is:closed) |
-| [Dhruv-Sachdev1313](https://github.com/Dhruv-Sachdev1313) | 18 | 2023-05-24 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Dhruv-Sachdev1313+is:closed) |
-| [kristiprogri](https://github.com/kristiprogri) | 13 | 2024-03-21 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:kristiprogri+is:closed) |
-| [spotz](https://github.com/spotz) | 12 | 2023-06-13 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:spotz+is:closed) |
-| [Gemarodri](https://github.com/Gemarodri) | 12 | 2022-09-21 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Gemarodri+is:closed) |
-| [Victorybrown](https://github.com/Victorybrown) | 11 | 2023-07-08 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Victorybrown+is:closed) |
-| [Delight362](https://github.com/Delight362) | 10 | 2024-03-28 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Delight362+is:closed) |
-| [kaxada](https://github.com/kaxada) | 10 | 2024-04-02 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:kaxada+is:closed) |
-| [Omokiti](https://github.com/Omokiti) | 9 | 2025-06-16 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Omokiti+is:closed) |
-| [riahtgl](https://github.com/riahtgl) | 9 | 2025-03-24 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:riahtgl+is:closed) |
-| [klumb](https://github.com/klumb) | 8 | 2025-03-05 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:klumb+is:closed) |
-| [Abenacodes](https://github.com/Abenacodes) | 8 | 2024-10-15 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Abenacodes+is:closed) |
-| [FeazUI](https://github.com/FeazUI) | 7 | 2024-10-15 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:FeazUI+is:closed) |
-| [LamiWilliams](https://github.com/LamiWilliams) | 6 | 2024-04-23 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:LamiWilliams+is:closed) |
-| [the-techgurl](https://github.com/the-techgurl) | 6 | 2024-04-08 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:the-techgurl+is:closed) |
-| [xiaoya-yaya](https://github.com/xiaoya-yaya) | 6 | 2022-10-20 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:xiaoya-yaya+is:closed) |
-| [Nene-S](https://github.com/Nene-S) | 5 | 2023-04-05 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Nene-S+is:closed) |
-| [bistaastha](https://github.com/bistaastha) | 5 | 2022-02-09 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:bistaastha+is:closed) |
-| [Joynels-Ogbogu](https://github.com/Joynels-Ogbogu) | 4 | 2023-08-17 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Joynels-Ogbogu+is:closed) |
-| [Nebrethar](https://github.com/Nebrethar) | 4 | 2022-12-07 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Nebrethar+is:closed) |
-| [geekygirldawn](https://github.com/geekygirldawn) | 3 | 2022-05-04 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:geekygirldawn+is:closed) |
-| [mollydb](https://github.com/mollydb) | 3 | 2022-02-09 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:mollydb+is:closed) |
-| [DesmondSanctity](https://github.com/DesmondSanctity) | 2 | 2024-05-16 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:DesmondSanctity+is:closed) |
-| [justwheel](https://github.com/justwheel) | 2 | 2020-08-13 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:justwheel+is:closed) |
-| [lucasgonze](https://github.com/lucasgonze) | 1 | 2022-12-08 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:lucasgonze+is:closed) |
-| [activus-d](https://github.com/activus-d) | 1 | 2022-11-24 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:activus-d+is:closed) |
-| [thecraftman](https://github.com/thecraftman) | 1 | 2022-05-11 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:thecraftman+is:closed) |
-| [uoduckswtd1](https://github.com/uoduckswtd1) | 1 | 2022-02-09 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:uoduckswtd1+is:closed) |
+| Reviewer | Total Reviews | Last Active | Last Assigned Date |Badge Level | Events Reviewed |
+|----------|---------------|-------------|--------------------|------------|-----------------|
+| [Ruth-ikegah](https://github.com/Ruth-ikegah) | 30 | 2023-08-17 | 2023-08-17 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Ruth-ikegah+is:closed)
+| [ElizabethN](https://github.com/ElizabethN) | 26 | 2025-06-26 | 2025-12-01 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:ElizabethN+is:closed)
+| [germonprez](https://github.com/germonprez) | 25 | 2024-03-18 | 2024-03-07 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:germonprez+is:closed)
+| [Dhruv-Sachdev1313](https://github.com/Dhruv-Sachdev1313) | 18 | 2023-05-24 | 2023-06-13 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Dhruv-Sachdev1313+is:closed)
+| [kristiprogri](https://github.com/kristiprogri) | 13 | 2024-03-21 | 2025-09-02 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:kristiprogri+is:closed)
+| [spotz](https://github.com/spotz) | 12 | 2023-06-13 | 2023-06-07 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:spotz+is:closed)
+| [Gemarodri](https://github.com/Gemarodri) | 12 | 2022-09-21 | 2022-10-17 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Gemarodri+is:closed)
+| [Victorybrown](https://github.com/Victorybrown) | 11 | 2023-07-08 | 2024-04-24 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Victorybrown+is:closed)
+| [Delight362](https://github.com/Delight362) | 10 | 2024-03-28 | 2024-10-14 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Delight362+is:closed)
+| [kaxada](https://github.com/kaxada) | 10 | 2024-04-02 | 2024-03-06 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:kaxada+is:closed)
+| [Omokiti](https://github.com/Omokiti) | 9 | 2025-06-16 | 2025-06-02 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Omokiti+is:closed)
+| [riahtgl](https://github.com/riahtgl) | 9 | 2025-03-24 | 2025-09-02 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:riahtgl+is:closed)
+| [klumb](https://github.com/klumb) | 8 | 2025-03-05 | 2025-02-25 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:klumb+is:closed)
+| [Abenacodes](https://github.com/Abenacodes) | 8 | 2024-10-15 | 2024-10-14 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Abenacodes+is:closed)
+| [FeazUI](https://github.com/FeazUI) | 7 | 2024-10-15 | 2024-10-14 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:FeazUI+is:closed)
+| [LamiWilliams](https://github.com/LamiWilliams) | 6 | 2024-04-23 | 2024-08-07 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:LamiWilliams+is:closed)
+| [the-techgurl](https://github.com/the-techgurl) | 6 | 2024-04-08 | 2024-04-02 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:the-techgurl+is:closed)
+| [xiaoya-yaya](https://github.com/xiaoya-yaya) | 6 | 2022-10-20 | 2022-10-13 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:xiaoya-yaya+is:closed)
+| [Nene-S](https://github.com/Nene-S) | 5 | 2023-04-05 | 2023-03-26 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Nene-S+is:closed)
+| [bistaastha](https://github.com/bistaastha) | 5 | 2022-02-09 | 2022-05-02 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:bistaastha+is:closed)
+| [Joynels-Ogbogu](https://github.com/Joynels-Ogbogu) | 4 | 2023-08-17 | 2023-07-23 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Joynels-Ogbogu+is:closed)
+| [Nebrethar](https://github.com/Nebrethar) | 4 | 2022-12-07 | 2021-10-11 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:Nebrethar+is:closed)
+| [geekygirldawn](https://github.com/geekygirldawn) | 3 | 2022-05-04 | 2022-10-13 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:geekygirldawn+is:closed)
+| [mollydb](https://github.com/mollydb) | 3 | 2022-02-09 | 2022-05-02 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:mollydb+is:closed)
+| [DesmondSanctity](https://github.com/DesmondSanctity) | 2 | 2024-05-16 | 2024-05-16 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:DesmondSanctity+is:closed)
+| [justwheel](https://github.com/justwheel) | 2 | 2020-08-13 | 2020-07-16 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:justwheel+is:closed)
+| [lucasgonze](https://github.com/lucasgonze) | 1 | 2022-12-08 | 2022-12-07 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:lucasgonze+is:closed)
+| [activus-d](https://github.com/activus-d) | 1 | 2022-11-24 | 2022-11-15 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:activus-d+is:closed)
+| [thecraftman](https://github.com/thecraftman) | 1 | 2022-05-11 | 2022-10-13 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:thecraftman+is:closed)
+| [uoduckswtd1](https://github.com/uoduckswtd1) | 1 | 2022-02-09 | 2021-10-06 | 🎖️ Honour | [View](https://github.com/badging/event-diversity-and-inclusion/issues?q=is:issue+assignee:uoduckswtd1+is:closed)
 
 ---
 
 ### Welcome Back Highlight  
 - @Mo-wo returned in Feb 2026 after a break! 🎉
 
-_Last Updated: 2026-02-16_  
+_Last Updated: 2026-02-17_  
 
 
 


### PR DESCRIPTION
**Summary:**  

Adds the **"Last Assigned Date"** column to the Reviewer Spotlight, tracking each reviewer’s most recent active assignment on open issues. Resolves issue #488.  

**Changes:**  

* `update_reviewers.py`  
  - Updated Reviewer Spotlight tables to include the **"Last Assigned Date"** column.  
* `README.md`  
  - Updated automatically by update_reviewers.py to include the new "Last Assigned Date" column

**Testing:**  

* Tested locally using the scenarios outlined in issue #488: simple assignment, re-assignment, un-assignment, and multiple assignees.  
* Confirmed **"Last Assigned Date"** updates correctly without affecting existing counts or formatting.  

**Additional Notes:**  

* Observation: the Spotlight currently tracks only reviewers with closed issues. Is there a way to also include contributors who’ve been assigned their first issue or tasks that haven’t been closed yet?

